### PR TITLE
updated main title section with 2023 info

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
             <a aria-label="HackNC snapchat" target="_blank" href="https://www.snapchat.com/add/hacknc">
                 <i class="fa fa-snapchat-square fa-2x"></i></a>
             <br>
-            <u>© HackNC 2023 — </u>
+            <u>© HackNC 2023 </u>
         </div>
     </footer>
     <script src="static/js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,11 @@
 
     <meta property="og:url" content="https://hacknc.com/">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="HackNC 2021">
+    <meta property="og:title" content="HackNC 2023">
     <meta property="og:description" content="UNC-Chapel Hill's annual fall hackathon" />
     <meta property="og:image" content="https://hacknc.com/static/assets/images/art/favicon.png" />
 
-    <title>HackNC 2021</title>
+    <title>HackNC 2023</title>
     <link rel="icon" type="image/png" sizes="32x32" href="static/assets/images/art/option2.png">
     <link href="https://fonts.googleapis.com/css?family=Arvo|Lobster+Two|Montserrat|Pacifico|Philosopher|Quicksand"
         rel="stylesheet">
@@ -99,16 +99,16 @@
             <a class="nav-anchor" id="home"></a>
             <div class="banner">
                 <div class="banner-info">
-                    <h1 class="tagline">HackNC 2021</h1>
-                    <h2 class="date">November 5-7, 2021</h2>
-                    <p class = "update"> Event Ended ...Stay tune for 2022 </p>
-                   
+                    <h1 class="tagline">HackNC 2023</h1>
+                    <h2 class="date">October 27-29, 2023</h2>
+                   <!-- <p class = "update"> Event Ended ...Stay tune for 2022 </p> -->
+                    
                     <!-- <button class="live-button hide-on-med-and-down"><a href="https://www.hacknc.com/live/">→ Event Live</a></button> -->
-                     <button class="involve-button hide-on-med-and-down"><a href="https://forms.gle/cqkwFZum1BihNbpKA">2022 Hacker Interest form</a></button>
-                     <button class="involve-button hide-on-med-and-down"><a href="https://tinyurl.com/HackNC2022Organizer">2022 Oganizer Interest form</a></button>
-                    <a class="apply" href="https://tinyurl.com/HackNC2022Organizer">2022 Oganizer Interest form</a>
+                    <!-- <button class="involve-button hide-on-med-and-down"><a href="https://forms.gle/cqkwFZum1BihNbpKA">2022 Hacker Interest form</a></button> -->
+                     <button class="involve-button hide-on-med-and-down"><a href="https://docs.google.com/forms/d/e/1FAIpQLSdobyqr0nq4ZXEZi0pdTGTBIuOZeEr5B26Wz71sij77ds15Xw/viewform">2023 Organizer Interest form</a></button>
+                    <a class="apply" href="https://docs.google.com/forms/d/e/1FAIpQLSdobyqr0nq4ZXEZi0pdTGTBIuOZeEr5B26Wz71sij77ds15Xw/viewform">2023 Organizer Interest form</a>
                    
-                    <a id="mobile-get-involved" class="apply" href="https://forms.gle/cqkwFZum1BihNbpKA">2022 Hacker Interest form</a>
+                   <!-- <a id="mobile-get-involved" class="apply" href="https://forms.gle/cqkwFZum1BihNbpKA">2022 Hacker Interest form</a> -->
                     <a id="mobile-get-involved" class="apply">Volunteer and mentor Sign up</a>
 
 
@@ -139,7 +139,7 @@
                     <div class="col s12">
                         <h1>Who we are</h1>
                         <p>HackNC is an annual, student-run hackathon hosted by the University of North Carolina at
-                            Chapel Hill. Every fall, hundreds of students arrive at UNC (this year, <b>we'll be having a hybrid hackathon!</b>) to spend the weekend inventing
+                            Chapel Hill. Every fall, hundreds of students arrive at UNC to spend the weekend inventing
                             something amazing. We’re one of the largest hackathons in the southeastern United States.
                         </p>
                     </div>
@@ -263,7 +263,7 @@
 
 
 
-                <p class="center sponsorFooter">Looking to sponsor HackNC 2021? Email us at <a class="sponsor-email"
+                <p class="center sponsorFooter">Looking to sponsor HackNC 2023? Email us at <a class="sponsor-email"
                         href="mailto:sponsorship@hacknc.com">sponsorship@hacknc.com</a></p>
             </div>
         </div>
@@ -288,7 +288,7 @@
             <a aria-label="HackNC snapchat" target="_blank" href="https://www.snapchat.com/add/hacknc">
                 <i class="fa fa-snapchat-square fa-2x"></i></a>
             <br>
-            <u>© HackNC 2021 — </u>
+            <u>© HackNC 2023 — </u>
         </div>
     </footer>
     <script src="static/js/main.js"></script>


### PR DESCRIPTION
This resolves task #2 from the Projects tab. I have also updated the outdated info in the footer(the "Looking to sponsor HackNC 2021? Email us at [sponsorship@hacknc.com](mailto:sponsorship@hacknc.com)" text and the copyright "HackNC 2021 – "). Also updated the meta and title info of the website.